### PR TITLE
Prevent npm from creating binstub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,7 @@
     "": {
       "name": "@nodenv/jetbrains-npm",
       "version": "1.0.1",
-      "license": "MIT",
-      "bin": {
-        "npm-cli.js": "bin/npm-cli.js"
-      }
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "directories": {
-    "bin": "bin",
-    "test": "test"
-  },
   "files": [
     "bin"
   ],


### PR DESCRIPTION
We do _not_ want the bin/* script from being added to any user's PATH.
So we do not want npm to know about bin/* as the special bin directory.
